### PR TITLE
結果画面への自動遷移を実現

### DIFF
--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -116,6 +116,7 @@
                 fast_talking_score: fast_talking_score,
               },
             });
+            location.href = '/games/result?' + fast_talking_score + "," + word_count + "," + talking_time;
           })
         }
       }


### PR DESCRIPTION
ユーザーが話し終えてfast_talking_scoreが正常に出たら結果画面に自動遷移するようにした。
ajaxのlocation.hrefを使用している。
#2 